### PR TITLE
ci: add OpenStack tox validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@d763fd8920390074628431db771a56ab4f7aa8e2 # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2244615e3b5ef56a6e83e993ede50ea9c3716cd7 # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2bed598442494c60f1f9ae004626473f7c400bf7 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2bed598442494c60f1f9ae004626473f7c400bf7 # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@d763fd8920390074628431db771a56ab4f7aa8e2 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@0dcf370eb08b3f884992181348b8c41d7f66c10e # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2244615e3b5ef56a6e83e993ede50ea9c3716cd7 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,21 @@ permissions:
   contents: read
 
 jobs:
+  tox:
+    name: tox (${{ matrix.project.repository }})
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@0dcf370eb08b3f884992181348b8c41d7f66c10e # main
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - repository: openstack/octavia
+            ref: 9ff4683c8212e4c043af69f1b5ebadc21651dc58 # master
+          - repository: openstack/ovn-octavia-provider
+            ref: 890b6266450916ddf9ef8c0a157f3fe4eb03e7a5 # master
+    with:
+      repository: ${{ matrix.project.repository }}
+      ref: ${{ matrix.project.ref }}
+
   image:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- add the shared docker-atmosphere tox reusable workflow to the build workflow
- test only the existing openstack/ checkout targets used by the image build
- keep each tox ref pinned to the same commit currently used by the image checkout
- set caller-level `fail-fast: false` so multi-project matrices report every OpenStack tox result

## Testing
- `nix-shell -p actionlint --run "actionlint .github/workflows/build.yml"`
- GitHub Actions tox checks were allowed to complete on this PR