### PR TITLE
Install Octavia from the Atmosphere index

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,18 +27,16 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@2b0040e59869e408a94f1e92e67fa47035c50336 # main
         with:
-          repository: openstack/octavia
-          ref: 78d38afc126c37e2ec65859e8cfc770eb5457075 # master
-
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@2b0040e59869e408a94f1e92e67fa47035c50336 # main
-        with:
           repository: openstack/ovn-octavia-provider
           ref: 890b6266450916ddf9ef8c0a157f3fe4eb03e7a5 # master
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@2b0040e59869e408a94f1e92e67fa47035c50336 # main
+      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@d87127d20ddb74d1760ba6af17db68945a37f835 # main
         with:
           image-name: octavia
+          build-args: |
+            UV_INDEX=${{ vars.UV_INDEX_URL }}
           build-contexts: |
-            octavia=openstack/octavia
             ovn-octavia-provider=openstack/ovn-octavia-provider
           push: ${{ github.event_name != 'pull_request' }}
+          tag-rules: |
+            type=raw,value=main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  OCTAVIA_VERSION: 18.0.0+a8e.3.1
+
 jobs:
   image:
     runs-on: ubuntu-latest
@@ -30,13 +33,13 @@ jobs:
           repository: openstack/ovn-octavia-provider
           ref: 890b6266450916ddf9ef8c0a157f3fe4eb03e7a5 # master
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@d87127d20ddb74d1760ba6af17db68945a37f835 # main
+      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@79be3331d9362131a646955c60feefceb1d7acf5 # main
         with:
           image-name: octavia
           build-args: |
             UV_INDEX=${{ vars.UV_INDEX_URL }}
+            OCTAVIA_VERSION=${{ env.OCTAVIA_VERSION }}
           build-contexts: |
             ovn-octavia-provider=openstack/ovn-octavia-provider
+          image-version: ${{ env.OCTAVIA_VERSION }}
           push: ${{ github.event_name != 'pull_request' }}
-          tag-rules: |
-            type=raw,value=main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           repository: openstack/ovn-octavia-provider
           ref: 890b6266450916ddf9ef8c0a157f3fe4eb03e7a5 # master
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@2dfa2fb47c1cc328b51043983b652e3c9bf62382 # main
+      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@2b0040e59869e408a94f1e92e67fa47035c50336 # main
         with:
           image-name: octavia
           build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,6 @@ jobs:
       - uses: vexxhost/docker-atmosphere/.github/actions/build-image@2b0040e59869e408a94f1e92e67fa47035c50336 # main
         with:
           image-name: octavia
-          build-args: |
-            UV_INDEX=${{ vars.UV_INDEX_URL }}
           build-contexts: |
             ovn-octavia-provider=openstack/ovn-octavia-provider
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ on:
 permissions:
   contents: read
 
-env:
-  OCTAVIA_VERSION: 18.0.0+a8e.3.1
-
 jobs:
   image:
     runs-on: ubuntu-latest
@@ -33,13 +30,11 @@ jobs:
           repository: openstack/ovn-octavia-provider
           ref: 890b6266450916ddf9ef8c0a157f3fe4eb03e7a5 # master
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@7aceccae174747a82bb634f475b48d89a7e31499 # main
+      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@2dfa2fb47c1cc328b51043983b652e3c9bf62382 # main
         with:
           image-name: octavia
           build-args: |
             UV_INDEX=${{ vars.UV_INDEX_URL }}
-            OCTAVIA_VERSION=${{ env.OCTAVIA_VERSION }}
           build-contexts: |
             ovn-octavia-provider=openstack/ovn-octavia-provider
-          image-version: ${{ env.OCTAVIA_VERSION }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           repository: openstack/ovn-octavia-provider
           ref: 890b6266450916ddf9ef8c0a157f3fe4eb03e7a5 # master
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@7638eb1af62be2752fbc0140aa186a6aace38049 # main
+      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@7aceccae174747a82bb634f475b48d89a7e31499 # main
         with:
           image-name: octavia
           build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           repository: openstack/ovn-octavia-provider
           ref: 890b6266450916ddf9ef8c0a157f3fe4eb03e7a5 # master
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@79be3331d9362131a646955c60feefceb1d7acf5 # main
+      - uses: vexxhost/docker-atmosphere/.github/actions/build-image@7638eb1af62be2752fbc0140aa186a6aace38049 # main
         with:
           image-name: octavia
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:336ba4260920dd0c401f4c11023ebee4752e90e49ef63f9840fb5dde0d0b3a9b AS build
 ARG UV_INDEX
-# renovate: datasource=pypi depName=octavia
 ARG OCTAVIA_VERSION=18.0.0+a8e.3.1
 RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Atmosphere-Rebuild-Time: 2024-06-25T22:49:25Z
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:336ba4260920dd0c401f4c11023ebee4752e90e49ef63f9840fb5dde0d0b3a9b AS build
-ARG UV_INDEX
+ENV UV_INDEX=https://packages.vexxhost.com/pypi/atmosphere/simple/
 ARG OCTAVIA_VERSION=18.0.0+a8e.3.1
 RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:336ba4260920dd0c401f4c11023ebee4752e90e49ef63f9840fb5dde0d0b3a9b AS build
 ARG UV_INDEX
-# renovate: datasource=pypi depName=octavia
-ARG OCTAVIA_VERSION=18.0.0+a8e.3.1
+ARG OCTAVIA_VERSION
 RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:336ba4260920dd0c401f4c11023ebee4752e90e49ef63f9840fb5dde0d0b3a9b AS build
 ARG UV_INDEX
-ARG OCTAVIA_VERSION
+# renovate: datasource=pypi depName=octavia
+ARG OCTAVIA_VERSION=18.0.0+a8e.3.1
 RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@
 # Atmosphere-Rebuild-Time: 2024-06-25T22:49:25Z
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:336ba4260920dd0c401f4c11023ebee4752e90e49ef63f9840fb5dde0d0b3a9b AS build
-RUN --mount=type=bind,from=octavia,source=/,target=/src/octavia,readwrite \
-    --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
+ARG UV_INDEX
+# renovate: datasource=pypi depName=octavia
+ARG OCTAVIA_VERSION=18.0.0+a8e.3.1
+RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
-        /src/octavia[redis] \
+        "octavia[redis]==${OCTAVIA_VERSION}" \
         /src/ovn-octavia-provider
 EOF
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>vexxhost/docker-atmosphere"]
+  "extends": ["local>vexxhost/docker-atmosphere"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update the pinned Octavia wheel",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+ARG OCTAVIA_VERSION=(?<currentValue>\\S+)"
+      ],
+      "versioningTemplate": "pep440"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>vexxhost/docker-atmosphere"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Update the pinned Octavia wheel",
-      "fileMatch": ["^\\.github/workflows/build\\.yml$"],
-      "matchStrings": [
-        "OCTAVIA_VERSION:\\s*(?<currentValue>\\S+)"
-      ],
-      "datasourceTemplate": "pypi",
-      "depNameTemplate": "octavia",
-      "versioningTemplate": "pep440"
-    }
-  ]
+  "extends": ["local>vexxhost/docker-atmosphere"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,12 @@
     {
       "customType": "regex",
       "description": "Update the pinned Octavia wheel",
-      "fileMatch": ["(^|/)Dockerfile$"],
+      "fileMatch": ["^\\.github/workflows/build\\.yml$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+ARG OCTAVIA_VERSION=(?<currentValue>\\S+)"
+        "OCTAVIA_VERSION:\\s*(?<currentValue>\\S+)"
       ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "octavia",
       "versioningTemplate": "pep440"
     }
   ]


### PR DESCRIPTION
## What changed

- install the exact `octavia[redis]==18.0.0+a8e.3.1` wheel from the public Atmosphere uv index
- remove the Octavia source checkout, build context, and bind mount
- keep `ovn-octavia-provider` installed from its existing pinned source checkout
- retain the existing shared image action and all existing image-tag behavior

## Why

VEXXHOST Octavia wheels now carry the downstream patch set. Consuming the immutable wheel removes the duplicate Octavia source checkout while leaving the surrounding image build and publication behavior unchanged.

## Validation

- `git diff --check`
- parsed the workflow with `yq`
- `actionlint .github/workflows/build.yml`
- verified the workflow contains no Octavia checkout or build context
- verified the workflow still uses the existing pinned docker-atmosphere action
- verified the pinned wheel exists at `https://packages.vexxhost.com/pypi/atmosphere/simple/`
