### PR TITLE
Install Octavia from the Atmosphere index

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,6 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@2b0040e59869e408a94f1e92e67fa47035c50336 # main
         with:
-          repository: openstack/octavia
-          ref: 2d14acc0d767de25cc840f375a7d44da192061be # stable/2026.1
-
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@2b0040e59869e408a94f1e92e67fa47035c50336 # main
-        with:
           repository: openstack/ovn-octavia-provider
           ref: 02df03efb44a7b0580ae6509f0b9bfbfacb5869d # stable/2026.1
 
@@ -39,6 +34,5 @@ jobs:
         with:
           image-name: octavia
           build-contexts: |
-            octavia=openstack/octavia
             ovn-octavia-provider=openstack/ovn-octavia-provider
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@
 # Atmosphere-Rebuild-Time: 2024-06-25T22:49:25Z
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:2026.1@sha256:0d814b5e8fbeb107f44d0597672084acee1fb90f6e0bf3720d5e27453e92ed15 AS build
-RUN --mount=type=bind,from=octavia,source=/,target=/src/octavia,readwrite \
-    --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
+ENV UV_INDEX=https://packages.vexxhost.com/pypi/atmosphere/simple/
+ARG OCTAVIA_VERSION=18.0.0+a8e.3.1
+RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
-        /src/octavia[redis] \
+        "octavia[redis]==${OCTAVIA_VERSION}" \
         /src/ovn-octavia-provider
 EOF
 


### PR DESCRIPTION
## Summary\n\n- install Octavia 18.0.0+a8e.3.1 from the public Atmosphere uv index\n- remove the Octavia source checkout, build context, and source mount\n- keep the OVN provider source checkout and the existing image tagging behavior\n\nRetains the redis extra.\n\n## Validation\n\n- confirmed the exact wheel exists in the Atmosphere package index\n- validated workflow YAML and Dockerfile invariants\n- git diff --check