### PR TITLE
Use the OpenStack Python package index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Atmosphere-Rebuild-Time: 2024-06-25T22:49:25Z
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:2024.1@sha256:e4e3d1ba79c1ba43d1d5afea8e882ff04ab250ad51e26b303f12e152b76a4514 AS build
-ENV UV_INDEX=https://packages.vexxhost.com/pypi/atmosphere/simple/
+ENV UV_INDEX=https://packages.vexxhost.com/pypi/openstack/simple/
 ARG OCTAVIA_VERSION=14.0.2+a8e.16.1
 RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \


### PR DESCRIPTION
The Pulp Python distribution has moved from the generic `atmosphere` base path to the product-specific `openstack` base path. Update the build-time `UV_INDEX` so published Octavia wheels continue to resolve from the renamed channel.