### PR TITLE
Use the OpenStack Python package index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Atmosphere-Rebuild-Time: 2024-06-25T22:49:25Z
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:2024.2@sha256:5f8bfdef9a688fef228b7889964a750dbe2e145e7baaed3390c3c877b3cdb367 AS build
-ENV UV_INDEX=https://packages.vexxhost.com/pypi/atmosphere/simple/
+ENV UV_INDEX=https://packages.vexxhost.com/pypi/openstack/simple/
 ARG OCTAVIA_VERSION=15.1.0+a8e.9.0
 RUN --mount=type=bind,from=ovn-octavia-provider,source=/,target=/src/ovn-octavia-provider,readwrite <<EOF bash -xe
 uv pip install \


### PR DESCRIPTION
The Pulp Python distribution has moved from the generic `atmosphere` base path to the product-specific `openstack` base path. Update the build-time `UV_INDEX` so published Octavia wheels continue to resolve from the renamed channel.